### PR TITLE
Styling tweaks 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -53,7 +53,7 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
-  text-align: center;
+  justify-content: center;
 }
 
 .type-choices {
@@ -156,4 +156,8 @@
 
 .my-draft-delete {
   padding-left: 15px;
+}
+
+.closet-container, .form-container {
+  margin: 0 20px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -158,6 +158,6 @@
   padding-left: 15px;
 }
 
-.closet-container, .form-container {
+.closet-container, .form-container, .outfit-container {
   margin: 0 20px;
 }

--- a/src/components/Closet.js
+++ b/src/components/Closet.js
@@ -97,7 +97,7 @@ const handleShoesChange = (event) => {
 
 return (
     <div className="closet-container">
-    <Button variant="contained" onClick={handleAllChange} value='all' size="small">All Clothing Items</Button>
+    <Button variant="contained" style={{marginBottom: '5px'}} onClick={handleAllChange} value='all' size="small">All Clothing Items</Button>
 <div className='buttons-box'>
     <ButtonGroup variant="contained" aria-label="outlined primary button group">
         <Button onClick={handleTopsChange} value="tops" color="secondary" size="small">Tops</Button>

--- a/src/components/Closet.js
+++ b/src/components/Closet.js
@@ -40,7 +40,7 @@ useEffect(() => {
         },
     })
     .then((res) => setItems(res.data))
-    
+
     // 2nd then request to get items in the current outfit
     .then((res) => {
         axios.get(
@@ -54,8 +54,8 @@ useEffect(() => {
         })
         .catch((error) => {
             console.log(error)
-        }) 
-        
+        })
+
     }, [token, url])
 
 
@@ -96,7 +96,7 @@ const handleShoesChange = (event) => {
 
 
 return (
-    <div> 
+    <div className="closet-container">
     <Button variant="contained" onClick={handleAllChange} value='all' size="small">All Clothing Items</Button>
 <div className='buttons-box'>
     <ButtonGroup variant="contained" aria-label="outlined primary button group">
@@ -110,7 +110,7 @@ return (
 
     <div className="items-container">
     <ShowItems draftItems={draftItems} setDraftItems={setDraftItems} items={items} setItems={setItems} url={url} currOutfit={currOutfit} setCurrOutfit={setCurrOutfit} setLoading={setLoading} token={token}/>
-    </div>      
+    </div>
     </div>
 </div>
 )

--- a/src/components/ClosetForm/FormClosetItems.js
+++ b/src/components/ClosetForm/FormClosetItems.js
@@ -164,7 +164,7 @@ export const FormClosetItem = ({token}) => {
     }, [category]);
 
     return(
-        <>
+        <div className="form-container">
             <form onSubmit={handleSubmit}>
                 <div>
                     <div className='add-item-instr'>Enter your closet item information.</div>
@@ -302,6 +302,7 @@ export const FormClosetItem = ({token}) => {
                             <label htmlFor='tags'>Tags </label>
                             <ReactTags
                                 tags={tags}
+                                autofocus={false}
                                 suggestions={suggestions}
                                 delimiters={delimiters}
                                 handleDelete={handleDelete}
@@ -320,7 +321,7 @@ export const FormClosetItem = ({token}) => {
 
                 </div>
             </form>
-        </>
+        </div>
     )
 }
 

--- a/src/components/CurrentOutfit.js
+++ b/src/components/CurrentOutfit.js
@@ -31,7 +31,7 @@ export const CurrentOutfit = ({ currOutfit, setCurrOutfit, loading, setLoading, 
     const handleClickOpen = () => {
         setOpen(true);
     };
-        
+
     const handleClose = () => {
         setOpen(false);
     };
@@ -59,7 +59,7 @@ export const CurrentOutfit = ({ currOutfit, setCurrOutfit, loading, setLoading, 
             })
             .catch((err) => console.error(err))
     }
-    
+
     // Clicking delete will delete outfit and change current outfit to empty
     const handleDeleteOutfit = () => {
         axios
@@ -99,27 +99,27 @@ export const CurrentOutfit = ({ currOutfit, setCurrOutfit, loading, setLoading, 
         comma: 188,
         enter: 13
     };
-    
+
     const delimiters = [KeyCodes.comma, KeyCodes.enter];
 
     const handleDelete = i => {
         setTags(tags.filter((tag, index) => index !== i));
     };
-    
+
     const handleAddition = tag => {
         setTags([...tags, tag]);
     };
-    
+
     const handleDrag = (tag, currPos, newPos) => {
         const newTags = tags.slice();
-    
+
         newTags.splice(currPos, 1);
         newTags.splice(newPos, 0, tag);
-    
+
         // re-render
         setTags(newTags);
     };
-    
+
     const handleTagClick = index => {
         console.log('The tag at index ' + index + ' was clicked');
     };
@@ -152,7 +152,7 @@ export const CurrentOutfit = ({ currOutfit, setCurrOutfit, loading, setLoading, 
     }, [tags])
 
 
-    // Loading symbol will display until currOutfit API call returns (in App.js) 
+    // Loading symbol will display until currOutfit API call returns (in App.js)
     if (loading) {
         return(
             <Box sx={{ display: 'flex' }}>
@@ -161,7 +161,7 @@ export const CurrentOutfit = ({ currOutfit, setCurrOutfit, loading, setLoading, 
         )
     } else {
         return(
-            <>
+            <div className="outfit-container">
 
                 {/* Only display if outfit has been started */}
                 {Object.keys(currOutfit).length === 0 ? "" :
@@ -171,6 +171,7 @@ export const CurrentOutfit = ({ currOutfit, setCurrOutfit, loading, setLoading, 
                 <input
                     type='text'
                     id='name'
+                    className='input'
                     value={name}
                     onChange = {(e) => setName(e.target.value)}
                     required
@@ -184,6 +185,7 @@ export const CurrentOutfit = ({ currOutfit, setCurrOutfit, loading, setLoading, 
                         <label htmlFor='tags'>Tags </label>
                         <ReactTags
                         tags={tags}
+                        autofocus={false}
                         suggestions={suggestions}
                         delimiters={delimiters}
                         handleDelete={handleDelete}
@@ -205,51 +207,53 @@ export const CurrentOutfit = ({ currOutfit, setCurrOutfit, loading, setLoading, 
 
                 {/* Only display if outfit has been started */}
                 {Object.keys(currOutfit).length === 0 ? "" :
-                <><div>
-                    <DisplayOutfit token={token} outfit={currOutfit} location='editOutfit' setCurrOutfit={setCurrOutfit} />
-                </div>
+                  <>
+                  <div>
+                      <DisplayOutfit token={token} outfit={currOutfit} location='editOutfit' setCurrOutfit={setCurrOutfit} />
+                  </div>
 
-                <div className='my-draft-buttons'>
-                    <span onClick={
-                        () => {
-                        handleSubmit()
-                    }
-                    }>
-                        <SaveButton />
-                    </span>
-                    <span className='my-draft-delete' onClick={(e) => {
-                    handleClickOpen()
-                    e.preventDefault()
-                    }}>
-                    <Button type="button" variant="contained" aria-label="delete outfit">
-                        Delete
-                    </Button>
-                    </span>
-                    <Dialog
-                    open={open}
-                    onClose={handleClose}
-                    aria-labelledby="alert-dialog-title"
-                    aria-describedby="alert-dialog-description"
-                >
-                    <DialogContent>
-                    <DialogContentText id="alert-dialog-description">
-                    Are you sure you want to delete?
-                    </DialogContentText>
-                    </DialogContent>
-                    <DialogActions>
-                        <div onClick={handleClose}>
-                    <Button type="button" onClick={(e) => e.preventDefault()} >Cancel</Button></div>
-                    <Button type="button" onClick={() => {
-                        handleDeleteOutfit()
-                        handleClose()
-                        }} autoFocus>
-                        Delete
-                    </Button>
-                    </DialogActions>
-                    </Dialog>
-                </div>
-                </>}
-            </>
+                  <div className='my-draft-buttons'>
+                      <span onClick={
+                          () => {
+                          handleSubmit()
+                      }
+                      }>
+                          <SaveButton />
+                      </span>
+                      <span className='my-draft-delete' onClick={(e) => {
+                      handleClickOpen()
+                      e.preventDefault()
+                      }}>
+                      <Button type="button" variant="contained" aria-label="delete outfit">
+                          Delete
+                      </Button>
+                      </span>
+                      <Dialog
+                      open={open}
+                      onClose={handleClose}
+                      aria-labelledby="alert-dialog-title"
+                      aria-describedby="alert-dialog-description"
+                  >
+                      <DialogContent>
+                      <DialogContentText id="alert-dialog-description">
+                      Are you sure you want to delete?
+                      </DialogContentText>
+                      </DialogContent>
+                      <DialogActions>
+                          <div onClick={handleClose}>
+                      <Button type="button" onClick={(e) => e.preventDefault()} >Cancel</Button></div>
+                      <Button type="button" onClick={() => {
+                          handleDeleteOutfit()
+                          handleClose()
+                          }} autoFocus>
+                          Delete
+                      </Button>
+                      </DialogActions>
+                      </Dialog>
+                  </div>
+                  </>
+                }
+            </div>
         )
     }
 }

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -2,13 +2,13 @@ import axios from "axios"
 import { useState } from "react"
 import Button from '@mui/material/Button';
 
-export const SearchBar = 
+export const SearchBar =
 ({setItems, token}) => {
     const [searchText, setSearchText] = useState('')
 
     const handleSearchCloset = (e) => {
         e.preventDefault();
-        
+
         axios
             .get(`https://stylehub.herokuapp.com/mycloset/?search=${searchText}`,
             {
@@ -31,6 +31,7 @@ export const SearchBar =
         <input
             type='text'
             id='search'
+            className='input'
             placeholder="search closet items"
             value={searchText}
             onChange = {(e) => setSearchText(e.target.value)}


### PR DESCRIPTION
Styling edits for Closet, AddItem, and CurrentOutfit.

Make styling with materialize more consistent on pages with inputs. Also add a consistent horizontal margin. 

The CurrentOutfit page layout is not finished -- @orlandorios I thought you might be intending to use the card format there as well so I left that alone.

<img width="344" alt="Screen Shot 2022-10-26 at 4 58 02 PM" src="https://user-images.githubusercontent.com/7226152/198137032-93323154-300c-4d8b-adda-3bb874420c50.png">

<img width="341" alt="Screen Shot 2022-10-26 at 4 58 10 PM" src="https://user-images.githubusercontent.com/7226152/198137025-d18d56d2-bae9-4f1b-a27f-e16fd2930069.png">


<img width="348" alt="Screen Shot 2022-10-26 at 5 00 03 PM" src="https://user-images.githubusercontent.com/7226152/198136992-177404c5-9acf-45c2-b3bb-dd086c9f7d0e.png">
